### PR TITLE
allow to handle error loading and loaded script

### DIFF
--- a/src/Snippets.js
+++ b/src/Snippets.js
@@ -1,39 +1,49 @@
-import warn from './utils/warn'
+import warn from "./utils/warn";
 
 // https://developers.google.com/tag-manager/quickstart
 
 const Snippets = {
   tags: function ({ id, events, dataLayer, dataLayerName, preview, auth }) {
-    const gtm_auth = `&gtm_auth=${auth}`
-    const gtm_preview = `&gtm_preview=${preview}`
+    const gtm_auth = `&gtm_auth=${auth}`;
+    const gtm_preview = `&gtm_preview=${preview}`;
 
-    if (!id) warn('GTM Id is required')
-    
+    if (!id) warn("GTM Id is required");
+
     const iframe = `
       <iframe src="https://www.googletagmanager.com/ns.html?id=${id}${gtm_auth}${gtm_preview}&gtm_cookies_win=x"
-        height="0" width="0" style="display:none;visibility:hidden" id="tag-manager"></iframe>`
-  
+        height="0" width="0" style="display:none;visibility:hidden" id="tag-manager"></iframe>`;
+
     const script = `
       (function(w,d,s,l,i){w[l]=w[l]||[];
-        w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js', ${JSON.stringify(events).slice(1, -1)}});
+        w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js', ${JSON.stringify(
+          events
+        ).slice(1, -1)}});
         var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
         j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+'${gtm_auth}${gtm_preview}&gtm_cookies_win=x';
+        j.addEventListener('error', function() {
+            var _ge = new CustomEvent('gtm_loading_error', { bubbles: true });
+            d.dispatchEvent(_ge);
+        });
+        j.addEventListener('load', function() {
+            var _ge = new CustomEvent('gtm_loaded', { bubbles: true });
+            d.dispatchEvent(_ge);
+        });
         f.parentNode.insertBefore(j,f);
-      })(window,document,'script','${dataLayerName}','${id}');`
-  
-    const dataLayerVar = this.dataLayer(dataLayer, dataLayerName)
-  
+      })(window,document,'script','${dataLayerName}','${id}');`;
+
+    const dataLayerVar = this.dataLayer(dataLayer, dataLayerName);
+
     return {
       iframe,
       script,
-      dataLayerVar
-    }
+      dataLayerVar,
+    };
   },
   dataLayer: function (dataLayer, dataLayerName) {
     return `
       window.${dataLayerName} = window.${dataLayerName} || [];
-      window.${dataLayerName}.push(${JSON.stringify(dataLayer)})`
-  }
-}  
+      window.${dataLayerName}.push(${JSON.stringify(dataLayer)})`;
+  },
+};
 
-module.exports = Snippets
+module.exports = Snippets;


### PR DESCRIPTION
Here is a workaround to handle when gtm throw error when loading script and handle when it's loaded.
What do you think about it ?

SImply handle it with window.addEventListener("gtm_loading_error", func) and window.addEventListener("gtm_loaded", func)