### PR TITLE
Add nonce parameter to the initialize function

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Look for gtm_auth and gtm_preview
 |events| `Object`| No | Additional events such as 'gtm.start': new Date().getTime(),event:'gtm.js'.|
 |auth| `String` | No | used to set environments. |
 |preview| `String` | No | used to set environments, something like `env-00`. |
+|nonce| `String` | No | used to add a [nonce](https://developers.google.com/tag-manager/web/csp) |
 
 
 ### Note:

--- a/src/TagManager.js
+++ b/src/TagManager.js
@@ -15,8 +15,11 @@ const TagManager = {
       return noscript
     }
 
-    const script = () => {
+    const script = (nonce) => {
       const script = document.createElement('script')
+      if (nonce) {
+        script.setAttribute('nonce', nonce);
+      }
       script.innerHTML = snippets.script
       return script
     }
@@ -29,17 +32,18 @@ const TagManager = {
       dataScript
     }
   },
-  initialize: function ({ gtmId, events = {}, dataLayer, dataLayerName = 'dataLayer', auth = '', preview = '' }) {
+  initialize: function ({ gtmId, events = {}, dataLayer, dataLayerName = 'dataLayer', auth = '', preview = '', nonce = undefined }) {
     const gtm = this.gtm({
       id: gtmId,
       events: events,
       dataLayer: dataLayer || undefined,
       dataLayerName: dataLayerName,
       auth,
-      preview
+      preview,
+      nonce
     })
     if (dataLayer) document.head.appendChild(gtm.dataScript)
-    document.head.insertBefore(gtm.script(), document.head.childNodes[0])
+    document.head.insertBefore(gtm.script(nonce), document.head.childNodes[0])
     document.body.insertBefore(gtm.noScript(), document.body.childNodes[0])
   },
   dataLayer: function ({dataLayer, dataLayerName = 'dataLayer'}) {

--- a/src/__tests__/TagManager.spec.js
+++ b/src/__tests__/TagManager.spec.js
@@ -16,4 +16,16 @@ describe('TagManager', () => {
     TagManager.initialize(gtmArgs)
     expect(window.dataLayer).toHaveLength(1)
   })
+
+  it('should render tagmanager with nonce', () => {
+    TagManager.initialize({gtmId: 'GTM-000000', nonce: 'foo'})
+    const scripts = window.document.getElementsByTagName('script');
+    expect(scripts[0].nonce).toBe('foo');
+  })
+
+  it('should render tagmanager without nonce', () => {
+    TagManager.initialize({gtmId: 'GTM-000000'})
+    const scripts = window.document.getElementsByTagName('script');
+    expect(scripts[0].nonce).toBe('');
+ })
 })


### PR DESCRIPTION
The recommended way to use Google Tag Manager with a Content Security Policy is to use a nonce.
Add a nonce parameter to the initialize function.

See https://developers.google.com/tag-manager/web/csp