### PR TITLE
Supports strict CSP

### DIFF
--- a/src/TagManager.js
+++ b/src/TagManager.js
@@ -1,9 +1,12 @@
 import Snippets from './Snippets'
 
 const TagManager = {
-  dataScript: function (dataLayer) {
+  dataScript: function (dataLayer, { nonce } = {}) {
     const script = document.createElement('script')
     script.innerHTML = dataLayer
+    if (nonce) {
+      script.nonce = nonce
+    }
     return script
   },
   gtm: function (args) {
@@ -18,10 +21,13 @@ const TagManager = {
     const script = () => {
       const script = document.createElement('script')
       script.innerHTML = snippets.script
+      if (args.nonce) {
+        script.nonce = args.nonce
+      }
       return script
     }
 
-    const dataScript = this.dataScript(snippets.dataLayerVar)
+    const dataScript = this.dataScript(snippets.dataLayerVar, { nonce: args.nonce })
 
     return {
       noScript,
@@ -29,23 +35,24 @@ const TagManager = {
       dataScript
     }
   },
-  initialize: function ({ gtmId, events = {}, dataLayer, dataLayerName = 'dataLayer', auth = '', preview = '' }) {
+  initialize: function ({ gtmId, events = {}, dataLayer, dataLayerName = 'dataLayer', auth = '', preview = '', nonce }) {
     const gtm = this.gtm({
       id: gtmId,
       events: events,
       dataLayer: dataLayer || undefined,
       dataLayerName: dataLayerName,
       auth,
-      preview
+      preview,
+      nonce
     })
     if (dataLayer) document.head.appendChild(gtm.dataScript)
     document.head.insertBefore(gtm.script(), document.head.childNodes[0])
     document.body.insertBefore(gtm.noScript(), document.body.childNodes[0])
   },
-  dataLayer: function ({dataLayer, dataLayerName = 'dataLayer'}) {
+  dataLayer: function ({dataLayer, dataLayerName = 'dataLayer', nonce}) {
     if (window[dataLayerName]) return window[dataLayerName].push(dataLayer)
     const snippets = Snippets.dataLayer(dataLayer, dataLayerName)
-    const dataScript = this.dataScript(snippets)
+    const dataScript = this.dataScript(snippets, { nonce })
     document.head.insertBefore(dataScript, document.head.childNodes[0])
   }
 }


### PR DESCRIPTION
Add nonce options to support strict CSP.

refs. https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src