### PR TITLE
Added the ability to override the default gtm url

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Look for gtm_auth and gtm_preview
 |events| `Object`| No | Additional events such as 'gtm.start': new Date().getTime(),event:'gtm.js'.|
 |auth| `String` | No | used to set environments. |
 |preview| `String` | No | used to set environments, something like `env-00`. |
+|url| `String` | No | used to override the default gtm url. |
 
 
 ### Note:

--- a/src/Snippets.js
+++ b/src/Snippets.js
@@ -3,21 +3,24 @@ import warn from './utils/warn'
 // https://developers.google.com/tag-manager/quickstart
 
 const Snippets = {
-  tags: function ({ id, events, dataLayer, dataLayerName, preview, auth }) {
+  tags: function ({ id, events, dataLayer, dataLayerName, preview, auth, url }) {
     const gtm_auth = `&gtm_auth=${auth}`
     const gtm_preview = `&gtm_preview=${preview}`
+    const pattern = /^(https:\/\/)/;
 
     if (!id) warn('GTM Id is required')
+
+    if(!pattern.test(url)) warn('URL needs to be a valid url')
     
     const iframe = `
-      <iframe src="https://www.googletagmanager.com/ns.html?id=${id}${gtm_auth}${gtm_preview}&gtm_cookies_win=x"
+      <iframe src="${url}/ns.html?id=${id}${gtm_auth}${gtm_preview}&gtm_cookies_win=x"
         height="0" width="0" style="display:none;visibility:hidden" id="tag-manager"></iframe>`
   
     const script = `
       (function(w,d,s,l,i){w[l]=w[l]||[];
         w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js', ${JSON.stringify(events).slice(1, -1)}});
         var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
-        j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+'${gtm_auth}${gtm_preview}&gtm_cookies_win=x';
+        j.async=true;j.src='${url}/gtm.js?id='+i+dl+'${gtm_auth}${gtm_preview}&gtm_cookies_win=x';
         f.parentNode.insertBefore(j,f);
       })(window,document,'script','${dataLayerName}','${id}');`
   

--- a/src/TagManager.js
+++ b/src/TagManager.js
@@ -29,14 +29,15 @@ const TagManager = {
       dataScript
     }
   },
-  initialize: function ({ gtmId, events = {}, dataLayer, dataLayerName = 'dataLayer', auth = '', preview = '' }) {
+  initialize: function ({ gtmId, events = {}, dataLayer, dataLayerName = 'dataLayer', auth = '', preview = '', url = "https://www.googletagmanager.com"}) {
     const gtm = this.gtm({
       id: gtmId,
       events: events,
       dataLayer: dataLayer || undefined,
       dataLayerName: dataLayerName,
       auth,
-      preview
+      preview,
+      url
     })
     if (dataLayer) document.head.appendChild(gtm.dataScript)
     document.head.insertBefore(gtm.script(), document.head.childNodes[0])


### PR DESCRIPTION
Added a non required param to the initialize method to be able to override the default tagmanager host.
Useful to enable server side tracking for tag manger