### PR TITLE
Add option to configure the server url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-gtm-module",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Snippets.js
+++ b/src/Snippets.js
@@ -3,21 +3,22 @@ import warn from './utils/warn'
 // https://developers.google.com/tag-manager/quickstart
 
 const Snippets = {
-  tags: function ({ id, events, dataLayer, dataLayerName, preview, auth }) {
+  tags: function ({ id, events, dataLayer, dataLayerName, preview, auth, serverUrl }) {
+    serverUrl = serverUrl || 'https://www.googletagmanager.com';
     const gtm_auth = `&gtm_auth=${auth}`
     const gtm_preview = `&gtm_preview=${preview}`
 
     if (!id) warn('GTM Id is required')
     
     const iframe = `
-      <iframe src="https://www.googletagmanager.com/ns.html?id=${id}${gtm_auth}${gtm_preview}&gtm_cookies_win=x"
+      <iframe src="${serverUrl}/ns.html?id=${id}${gtm_auth}${gtm_preview}&gtm_cookies_win=x"
         height="0" width="0" style="display:none;visibility:hidden" id="tag-manager"></iframe>`
   
     const script = `
       (function(w,d,s,l,i){w[l]=w[l]||[];
         w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js', ${JSON.stringify(events).slice(1, -1)}});
         var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
-        j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl+'${gtm_auth}${gtm_preview}&gtm_cookies_win=x';
+        j.async=true;j.src='${serverUrl}/gtm.js?id='+i+dl+'${gtm_auth}${gtm_preview}&gtm_cookies_win=x';
         f.parentNode.insertBefore(j,f);
       })(window,document,'script','${dataLayerName}','${id}');`
   

--- a/src/TagManager.js
+++ b/src/TagManager.js
@@ -29,14 +29,15 @@ const TagManager = {
       dataScript
     }
   },
-  initialize: function ({ gtmId, events = {}, dataLayer, dataLayerName = 'dataLayer', auth = '', preview = '' }) {
+  initialize: function ({ gtmId, events = {}, dataLayer, serverUrl = '', dataLayerName = 'dataLayer', auth = '', preview = '' }) {
     const gtm = this.gtm({
       id: gtmId,
       events: events,
       dataLayer: dataLayer || undefined,
       dataLayerName: dataLayerName,
       auth,
-      preview
+      preview,
+      serverUrl
     })
     if (dataLayer) document.head.appendChild(gtm.dataScript)
     document.head.insertBefore(gtm.script(), document.head.childNodes[0])

--- a/src/__tests__/Snippets.spec.js
+++ b/src/__tests__/Snippets.spec.js
@@ -12,15 +12,21 @@ describe('Snippets', () => {
   it('should use the `id` for the iframe', () => {
     expect(snippets.iframe).toContain(`id=${args.id}`, 1)
   })
+
+  it('should use the default server url', () => {
+    expect(snippets.iframe).toContain(`src="https://www.googletagmanager.com`, 1)
+  });
   
   it('should use the `gtm_auth` and `gtm_preview` for the iframe', () => {
     Object.assign(args, {
       auth: '6sBOnZx1hqPcO01xPOytLK',
-      preview: 'env-2'
+      preview: 'env-2',
+      serverUrl: 'https://my-server-url'
     })
     snippets = Snippets.tags(args)
     expect(snippets.iframe).toContain(`gtm_auth=${args.auth}`, 1)
     expect(snippets.iframe).toContain(`gtm_preview=${args.preview}`, 1)
+    expect(snippets.iframe).toContain(`src="https://my-server-url`, 1)
   })
 
   it('should use the `dataLayer` for the script', () => {


### PR DESCRIPTION
In order to use this with 3rd party server side tracking services such as [stape](https://stape.io), we need the ability to configure the server url. I've added this option.